### PR TITLE
Make sign up line up

### DIFF
--- a/app/assets/stylesheets/screen.css.scss
+++ b/app/assets/stylesheets/screen.css.scss
@@ -95,7 +95,7 @@ header, section, footer {
   height:$heart_width;
   width:$heart_width;
 
-  @media screen and (max-width: 629px) { 
+  @media screen and (max-width: 629px) {
     top:114px;
   }
 }
@@ -157,6 +157,9 @@ footer {
 	& a {
 		font-weight: bold;
 	}
+  p:first-child {
+    min-height: 65px;
+  }
 
   a {
     background-color: #e9f193;

--- a/app/assets/stylesheets/screen.css.scss
+++ b/app/assets/stylesheets/screen.css.scss
@@ -157,7 +157,7 @@ footer {
 	& a {
 		font-weight: bold;
 	}
-  p:first-child {
+  .panel-information {
     min-height: 65px;
   }
 

--- a/app/views/availabilities/index.html.erb
+++ b/app/views/availabilities/index.html.erb
@@ -9,7 +9,7 @@
 
   <% @availabilities.each do |a| %>
     <div class="panel">
-    	<p>
+    	<p class="panel-information">
     		<%= image_tag a.mentor.gravatar_url, :class => "left" %>
     		<span aria-hidden="true" class="icon" data-icon="&hearts;"></span>
     	  <%= link_to a.mentor.name, user_path(a.mentor) %>


### PR DESCRIPTION
First commit specifies first child <p> min-height to push the sign-up link down.

Second commit specifics new specific class on the <p> so p:first-child { min-height: 65px } doesn't cause unintended changes elsewhere.