### PR TITLE
Adding panel for when no availabilities for a filter option

### DIFF
--- a/app/assets/javascripts/availabilities/availability_filtering.js
+++ b/app/assets/javascripts/availabilities/availability_filtering.js
@@ -3,12 +3,22 @@ $(document).ready(function(){
 	$("#city-filter").on("change", function(event){
 		var city = $(this).val();
 
-    $("#availabilities div.panel:not(#filter)").fadeOut();
+    $("#availabilities div.panel:not(#filter)").hide();
+    $("#no-availability-city").text("");
 
     if(city === "All") {
-      $("#availabilities div.panel:not(#filter)").fadeIn();
+      $("#availabilities div.panel:not(#filter, #no-availability)").fadeIn();
     } else {
-      $("#availabilities div.panel[data-city='"+city+"']").fadeIn();
+
+      var city_availabilities = $("#availabilities div.panel[data-city='"+city+"']");
+
+      if(city_availabilities.length > 0) {
+        $("#availabilities div.panel[data-city='"+city+"']").fadeIn();
+      } else {
+        $("#no-availability-city").text(city);
+        $("#availabilities div.panel[id='no-availability']").fadeIn();
+      }
+
     }
 	});
 

--- a/app/assets/stylesheets/screen.css.scss
+++ b/app/assets/stylesheets/screen.css.scss
@@ -427,6 +427,10 @@ label {
   width: 150px;
 }
 
+#no-availability {
+  display:none;
+}
+
 .field {
 	border-top: 1px dashed #ccc;
 	padding-top: 1em;

--- a/app/views/availabilities/index.html.erb
+++ b/app/views/availabilities/index.html.erb
@@ -13,6 +13,9 @@
          <%= options_for_select(Location::CITY_NAMES) %>
        </select>
     </div>
+    <div class="panel" id="no-availability">
+      <p><span aria-hidden="true" class="icon" data-icon="&hearts;"></span> There currently aren't any mentoring availabilities for <span id="no-availability-city"></span>.<br><%= link_to "Offer to mentor someone!", new_availability_path %></p>
+    </div>
     <% @availabilities.each do |a| %>
       <div class="panel" data-city="<%= a.city %>">
       	<p class="panel-information">


### PR DESCRIPTION
Location filtering branch failed to take into account when there isn't any availabilities for a filter option.  This takes care of that.  This fully closes #99 

![screen shot 2015-02-02 at 1 18 51 pm](https://cloud.githubusercontent.com/assets/439941/6007205/29f1db4e-aade-11e4-940f-2e30743241fa.png)
