### PR TITLE
Added client side validations for required fields

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,4 +16,5 @@
 //= require availabilities/availability_recurrence
 //= require availabilities/new_form
 //= require availabilities/new
+//= require validator
 //= require_tree .

--- a/app/assets/javascripts/appointment_requests/new.js
+++ b/app/assets/javascripts/appointment_requests/new.js
@@ -1,0 +1,7 @@
+$(document).ready(function(){
+  $("#appointment_request").on("submit", function(event){
+    var fields = [$("#first_name"), $("#last_name"), $("#email")];
+    return toggleErrors(fields);
+  });
+});
+

--- a/app/assets/javascripts/availabilities/new.js
+++ b/app/assets/javascripts/availabilities/new.js
@@ -3,4 +3,9 @@ $(function () {
     dateFormat: 'yy-mm-dd',
     showOtherMonths: true,
     selectOtherMonths: true});
+
+  $("#availability").on("submit", function(event){
+    var fields = [$("#first_name"), $("#last_name"), $("#email"), $("#availability_duration"), $("#availability_location")];
+    return toggleErrors(fields);
+  });
 });

--- a/app/assets/javascripts/validator.js
+++ b/app/assets/javascripts/validator.js
@@ -1,0 +1,16 @@
+function toggleErrors(fields) {
+  var noErrors = true;
+
+  for(var i = 0; i < fields.length; i++) {
+
+    if(fields[i].val()) {
+      fields[i].removeClass("field_error");
+    } else {
+      noErrors = false;
+      fields[i].addClass("field_error");
+    }
+
+  }
+
+  return noErrors;
+}

--- a/app/assets/stylesheets/screen.css.scss
+++ b/app/assets/stylesheets/screen.css.scss
@@ -452,6 +452,10 @@ input#first_name {
 	display: none;
 }
 
+.field_error {
+  border: 2px solid $base;
+}
+
 /* $ICONS ********************************************************************/
 
 .icon {

--- a/app/views/appointment_requests/new.html.erb
+++ b/app/views/appointment_requests/new.html.erb
@@ -3,7 +3,7 @@
 <div class="panel">
 	<p>With <%= link_to(@availability.mentor.name) %> on <%= display_availability(@availability) %></p>
 
-	<%= form_tag appointment_requests_path(:availability_id => @availability) do %>
+	<%= form_tag appointment_requests_path(:availability_id => @availability), id: "appointment_request" do %>
 	<p>Name <%= text_field_tag :first_name, params[:first_name] %><%= text_field_tag :last_name, params[:last_name] %></p>
 	<p>Twitter handle <%= text_field_tag :twitter_handle, params[:twitter_handle] %></p>
 	<p>Email address <%= text_field_tag :email, params[:email] %></p>

--- a/app/views/availabilities/new.html.erb
+++ b/app/views/availabilities/new.html.erb
@@ -8,7 +8,7 @@
 </div>
 
 <div class="panel">
-  <%= form_tag availabilities_path do %>
+  <%= form_tag availabilities_path, id: "availability" do %>
     <div class="field"><label>Email address</label><%= text_field_tag :email %></div>
     <div class="field"><label>Name</label><%= text_field_tag :first_name %><%= text_field_tag :last_name %></div>
     <div class="field"><label>Twitter handle<span class="addon">@</span></label><%= text_field_tag :twitter_handle %></div>


### PR DESCRIPTION
Added client side validations to both the 'sign up' form and the 'offer to mentor' form that highlight the required fields in the base color if they are not entered.  Form submission is prevented until all required fields are entered. 

#### Sign up form
![screen shot 2015-02-06 at 11 08 29 am](https://cloud.githubusercontent.com/assets/439941/6083774/eb494d1c-adf0-11e4-9bc4-92207dbb6eee.png)

#### Top of Offer to Mentor Form
![screen shot 2015-02-06 at 11 08 54 am](https://cloud.githubusercontent.com/assets/439941/6083778/f387312e-adf0-11e4-9753-2744edb2e634.png)

#### Bottom of Offer to Mentor Form,
![screen shot 2015-02-06 at 11 08 46 am](https://cloud.githubusercontent.com/assets/439941/6083781/f9bdfec4-adf0-11e4-9d21-56722dee115d.png)
