### PR TITLE
Fix email format errors by expecting flat text email only.

### DIFF
--- a/app/views/user_mailer/feedback_request.text.erb
+++ b/app/views/user_mailer/feedback_request.text.erb
@@ -1,6 +1,5 @@
 Hey <%= @giver.name %>!
 
-How did your pairing session with <%= @receiver.name %> go? Please take a
-minute to<a href="mailto:<%=@receiver.email%>?subject=Thanks for our session"> send a thank you email</a>! Follow up on how your session went! Give them the title of that movie you couldn't remember until after the session!
+How did your pairing session with <%= @receiver.name %> go? Please take a minute to send a thank you email to <%= @receiver.first_name %> at: <%= @receiver.email %>! Follow up on how your session went! Give them the title of that movie you couldn't remember until after the session!
 
-Also, please provide some feedback for them at our <a href="<%=new_appointment_feedback_url(@giver.activation_code, :appointment_id => @appointment.id)%>">feedback page</a>. We'll pass it along to them for you.
+Also, please provide some feedback for them at our feedback page (found at <%= new_appointment_feedback_url(@giver.activation_code, :appointment_id => @appointment.id) %>). We'll pass it along to them for you.


### PR DESCRIPTION
I believe this should address the error reported in issue 145.

Since the email format looks to be text only and isn't rendering the html appropriately, just set it to make sense with straight text. This is in line with the other email templates in the application.