### PR TITLE
Fixes formatting issue with user twitter handles.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,10 @@ module ApplicationHelper
     "https://twitter.com/" + m.twitter_handle
   end
 
+  def display_twitter_handle(handle)
+    handle && ("@" + handle.sub(/^@/, ''))
+  end
+
   def month_link(symbol, month)
     link_to symbol, :month => month.strftime("%Y-%m-01")
   end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
 
   <div class="profile_content_wrap right">
     <p>
-      <a href=<%= href_to_twitters_user(@user) %>><%= "@#{@user.try(:twitter_handle)}" %><%= image_tag("twitter_black_logo.jpg")%></a>
+      <a href=<%= href_to_twitters_user(@user) %>><%= display_twitter_handle(@user.twitter_handle)  %><%= image_tag("twitter_black_logo.jpg")%></a>
     </p>
 
     <% if @user.bio %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -58,4 +58,18 @@ describe ApplicationHelper do
       expect(future_or_past_tense(start_time)).to eq("mentored")
     end
   end
+
+  context "#display_twitter_handle" do
+    it "returns an empty string when the user doesn't have a handle" do
+      expect(display_twitter_handle(nil)).to be_nil
+    end
+
+    it "returns the string w/ a leading arobase (at-sign?)" do
+      expect(display_twitter_handle("bob")).to eq "@bob"
+    end
+
+    it "strips extraneous symbols from the front" do
+      expect(display_twitter_handle("@bob")).to eq "@bob"
+    end
+  end
 end


### PR DESCRIPTION
Example: http://mentoring.devbootcamp.com/users/853

Data isn't formatted on the way into the DB (which is another fix that should probably be applied here), but in the interim let's be accepting of other people's twitter formatting.

Adds a few tests while we're at it.