### PR TITLE
Issue #153 and refactor feature spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :development, :test do
   gem "rake"
   gem "faker"
   gem "rspec-rails"
-  gem "shoulda-matchers"
+  gem "shoulda-matchers", require: false
   gem "coveralls", :require => false
 end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,5 @@
 class UserMailer < ActionMailer::Base
-  default from: "chicago.lead.mentor@devbootcamp.com"
+  default from: "no-reply@devbootcamp.com"
   add_template_helper(ApplicationHelper)
 
   def user_activation(user)
@@ -41,7 +41,7 @@ class UserMailer < ActionMailer::Base
     @mentor = appointment.mentor
     @mentee = appointment.mentee
 
-    mail(:to => [@mentee.email,@mentor.email], :subject => "Mentoring appointment canceled")   
+    mail(:to => [@mentee.email,@mentor.email], :subject => "Mentoring appointment canceled")
   end
 
   def feedback_request(appointment, giver, receiver)

--- a/app/views/user_mailer/appointment_confirmation.text.erb
+++ b/app/views/user_mailer/appointment_confirmation.text.erb
@@ -8,3 +8,6 @@ If you have any questions about the mentoring session, reach out to <%= @mentor.
 
 Enjoy!
 Dev Bootcamp
+
+Please do not reply to this message. This is an unmonitored mailbox.
+If you have a question about the mentoring email process, please contact your local DBC mentor coordinator.

--- a/app/views/user_mailer/appointment_deletion.text.erb
+++ b/app/views/user_mailer/appointment_deletion.text.erb
@@ -6,3 +6,6 @@ Please check <%= root_url %> to find another mentoring opportunity or to post ne
 
 Enjoy!
 Dev Bootcamp
+
+Please do not reply to this message. This is an unmonitored mailbox.
+If you have a question about the mentoring email process, please contact your local DBC mentor coordinator.

--- a/app/views/user_mailer/appointment_rejection.text.erb
+++ b/app/views/user_mailer/appointment_rejection.text.erb
@@ -6,3 +6,6 @@ Please check <a href="http://mentoring.devbootcamp.com">mentoring.devbootcamp.co
 
 Enjoy!
 Dev Bootcamp
+
+Please do not reply to this message. This is an unmonitored mailbox.
+If you have a question about the mentoring email process, please contact your local DBC mentor coordinator.

--- a/app/views/user_mailer/appointment_request.text.erb
+++ b/app/views/user_mailer/appointment_request.text.erb
@@ -11,3 +11,6 @@ Once you're ready to proceed, please click this link to confirm that you're up f
 
 Thanks,
 Dev Bootcamp
+
+Please do not reply to this message. This is an unmonitored mailbox.
+If you have a question about the mentoring email process, please contact your local DBC mentor coordinator.

--- a/app/views/user_mailer/feedback_request.text.erb
+++ b/app/views/user_mailer/feedback_request.text.erb
@@ -3,3 +3,9 @@ Hey <%= @giver.name %>!
 How did your pairing session with <%= @receiver.name %> go? Please take a minute to send a thank you email to <%= @receiver.first_name %> at: <%= @receiver.email %>! Follow up on how your session went! Give them the title of that movie you couldn't remember until after the session!
 
 Also, please provide some feedback for them at our feedback page (found at <%= new_appointment_feedback_url(@giver.activation_code, :appointment_id => @appointment.id) %>). We'll pass it along to them for you.
+
+Thanks,
+Dev Bootcamp
+
+Please do not reply to this message. This is an unmonitored mailbox.
+If you have a question about the mentoring email process, please contact your local DBC mentor coordinator.

--- a/app/views/user_mailer/management_link.text.erb
+++ b/app/views/user_mailer/management_link.text.erb
@@ -1,4 +1,7 @@
 <%= edit_user_url(@user.activation_code) %>
 
-This is your Pairing is Caring user management link. You can use it to view 
+This is your Pairing is Caring user management link. You can use it to view
 your current availabilities and appointments. Keep this handy!
+
+Please do not reply to this message. This is an unmonitored mailbox.
+If you have a question about the mentoring email process, please contact your local DBC mentor coordinator.

--- a/app/views/user_mailer/new_feedback_notification.text.erb
+++ b/app/views/user_mailer/new_feedback_notification.text.erb
@@ -1,4 +1,7 @@
-Someone has left you feedback about a recent Pairing is Caring session you 
+Someone has left you feedback about a recent Pairing is Caring session you
 participated in! You can view all of your recent feedback at here:
 
 <%= feedback_user_url(@feedback.feedback_receiver.activation_code) %>
+
+Please do not reply to this message. This is an unmonitored mailbox.
+If you have a question about the mentoring email process, please contact your local DBC mentor coordinator.

--- a/app/views/user_mailer/user_activation.text.erb
+++ b/app/views/user_mailer/user_activation.text.erb
@@ -2,8 +2,11 @@ Hi <%= @user.name %>!
 
 Please click this link to confirm that you're a real-live person: <%= @url %>
 
-Once you've been activated, we will send you a link that will allow you to 
+Once you've been activated, we will send you a link that will allow you to
 manage your availabilities and appointments.
 
 Thanks,
 Dev Bootcamp
+
+Please do not reply to this message. This is an unmonitored mailbox.
+If you have a question about the mentoring email process, please contact your local DBC mentor coordinator.

--- a/spec/features/mentor_creates_availability_feature.rb
+++ b/spec/features/mentor_creates_availability_feature.rb
@@ -1,29 +1,24 @@
 require 'spec_helper'
 
 feature "Mentor creates availability" do
+
   context "when the mentor provides valid input" do
-    it "persists the availability to the database" do
-      mentor = FactoryGirl.create(:mentor)
+    given(:mentor) { FactoryGirl.create :mentor }
 
-      visit new_availability_path
-      fill_in :first_name, with: mentor.first_name
-      fill_in :last_name, with: mentor.last_name
-      fill_in :email, with: mentor.email
-      fill_in :twitter_handle, with: mentor.twitter_handle
-      fill_in :availability_duration, with: 60
-
-
+    scenario "persists the availability to the database" do
       mentoring_time = 1.week.from_now.change(:hour => 18, :min => 45).beginning_of_minute
-      select_datetime(mentoring_time, :availability_start_time)
+      visit new_availability_path
 
-      click_on :submit_availability
+      new_availability_form(mentor, mentoring_time)
 
       expect(page).to have_content "#{mentor.name} on #{mentoring_time.strftime("%m/%d/%Y")} from 6:45pm"
     end
   end
 
   context "when displaying the availabity request" do
-    it "displays the user's full name" do
+    given(:mentor) { FactoryGirl.create :mentor }
+
+    scenario "displays the user's full name" do
       availability = FactoryGirl.create(:availability)
       visit "/"
 
@@ -37,48 +32,27 @@ feature "Mentor creates availability" do
   end
 
   context "when the mentor provides recurrence parameters" do
-    it "persists the availabilities to the database" do
-      mentor = FactoryGirl.create(:mentor)
+    given(:mentor) { FactoryGirl.create :mentor }
 
-      visit new_availability_path
-      fill_in :first_name, with: mentor.first_name
-      fill_in :last_name, with: mentor.last_name
-      fill_in :email, with: mentor.email
-      fill_in :twitter_handle, with: mentor.twitter_handle
-      fill_in :availability_duration, with: 60
-
+    scenario "persists the availabilities to the database" do
       mentoring_time = 1.week.from_now
-      select_datetime(mentoring_time, :availability_start_time)
-      check :availability_setup_recurring
-      select("week", :from => :availability_recur_weekly)
-      select("1", :from => :availability_recur_num)
+      visit new_availability_path
 
       expect {
-        click_on :submit_availability
+        new_availability_form_recurring(mentor, mentoring_time)
       }.to change(Availability, :count).by(2)
     end
 
-    it "all availabilities are viewable by mentor" do
-      mentor = FactoryGirl.create(:mentor)
-
-      visit new_availability_path
-      fill_in :first_name, with: mentor.first_name
-      fill_in :last_name, with: mentor.last_name
-      fill_in :email, with: mentor.email
-      fill_in :twitter_handle, with: mentor.twitter_handle
-      fill_in :availability_duration, with: 60
-
-      mentoring_time = 1.week.from_now.change(:hour => 12, :min => 45).beginning_of_minute
+    scenario "all availabilities are viewable by mentor" do
+      mentoring_time = 1.week.from_now.change(hour: 12, min: 45).beginning_of_minute
       second_time = mentoring_time + 7.days
-      select_datetime(mentoring_time, :availability_start_time)
-      check :availability_setup_recurring
-      select("week", :from => :availability_recur_weekly)
-      select("1", :from => :availability_recur_num)
+      visit new_availability_path
 
-      click_on :submit_availability
+      new_availability_form_recurring(mentor, mentoring_time)
 
-      expect(page).to have_content "#{mentor.name} on #{mentoring_time.strftime("%m/%d/%Y")} from 12:45pm"
-      expect(page).to have_content "#{mentor.name} on #{second_time.strftime("%m/%d/%Y")} from 12:45pm"
+      [mentoring_time, second_time].each do |time|
+        expect(page).to have_content "#{mentor.name} on #{time.strftime("%m/%d/%Y")} from 12:45pm"
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
+require 'shoulda-matchers'
 
 require 'coveralls'
 Coveralls.wear!('rails')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,8 @@ end
 ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
 
 RSpec.configure do |config|
+
+  config.include FormHelper, type: :feature
   # ## Mock Framework
   #
   # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:

--- a/spec/support/form_helper.rb
+++ b/spec/support/form_helper.rb
@@ -1,0 +1,24 @@
+module FormHelper
+  def new_availability_form(mentor, mentoring_time)
+    fill_in :first_name, with: mentor.first_name
+    fill_in :last_name, with: mentor.last_name
+    fill_in :email, with: mentor.email
+    fill_in :twitter_handle, with: mentor.twitter_handle
+    fill_in :availability_duration, with: 60
+    select_datetime(mentoring_time, :availability_start_time)
+    click_on :submit_availability
+  end
+
+  def new_availability_form_recurring(mentor, mentoring_time)
+    fill_in :first_name, with: mentor.first_name
+    fill_in :last_name, with: mentor.last_name
+    fill_in :email, with: mentor.email
+    fill_in :twitter_handle, with: mentor.twitter_handle
+    fill_in :availability_duration, with: 60
+    select_datetime(mentoring_time, :availability_start_time)
+    check :availability_setup_recurring
+    select("week", :from => :availability_recur_weekly)
+    select("1", :from => :availability_recur_num)
+    click_on :submit_availability
+  end
+end


### PR DESCRIPTION
I couldn't get my server to run without changing the shoulda-matchers gem to require: false and requiring it explicitly in the spec_helper.  I hope this change is acceptable.  Please let me know if there's a reason I shouldn't be doing this that I don't know about and I'll change it back.  I was getting some weird errors without it and couldn't find another fix though.

Also, there were no tests for the mailer so I just left it untested.  I hope this is helpful!  All feedback is welcome.  :-D

@alycit 