### PR TITLE
feat(requests): warn mentees when there are other requests pending

### DIFF
--- a/app/assets/stylesheets/screen.css.scss
+++ b/app/assets/stylesheets/screen.css.scss
@@ -207,6 +207,11 @@ footer {
   border-bottom: 1px solid lighten($base, 10%);
 }
 
+.panel .alert {
+  color: #666;
+  font-style: italic;
+}
+
 .left {
 	float: left;
 }

--- a/app/controllers/appointment_requests_controller.rb
+++ b/app/controllers/appointment_requests_controller.rb
@@ -1,6 +1,7 @@
 class AppointmentRequestsController < ApplicationController
   def new
     @availability = Availability.find_by_id(params[:availability_id])
+    @requests = @availability.appointment_requests
     return redirect_to availabilities_path unless @availability.present?
   end
 

--- a/app/views/appointment_requests/_existing_request.html.erb
+++ b/app/views/appointment_requests/_existing_request.html.erb
@@ -1,0 +1,1 @@
+<p class="alert">Head's up: Another mentee request for this session exists, but hasn't been confirmed.</p>

--- a/app/views/appointment_requests/new.html.erb
+++ b/app/views/appointment_requests/new.html.erb
@@ -1,6 +1,7 @@
 <h2>Sign up</h2>
 
 <div class="panel">
+  <%= render(partial: "existing_request") if @requests.any? %>
 	<p>With <%= link_to(@availability.mentor.name) %> on <%= display_availability(@availability) %></p>
 
 	<%= form_tag appointment_requests_path(:availability_id => @availability), id: "appointment_request" do %>

--- a/spec/controllers/appointment_requests_controller_spec.rb
+++ b/spec/controllers/appointment_requests_controller_spec.rb
@@ -1,6 +1,22 @@
 require 'spec_helper'
 
 describe AppointmentRequestsController do
+  describe "#new" do
+    render_views
+
+    it "warns you if someone else has requested this availability" do
+      mentee = FactoryGirl.create(:mentee, activated: true)
+      availability = FactoryGirl.create(:availability)
+
+      get :new, availability_id: availability.id
+      expect(response).not_to render_template(partial: "_existing_request")
+
+      availability.appointment_requests.create!(mentee: mentee)
+      get :new, availability_id: availability.id
+      expect(response).to render_template(partial: "_existing_request")
+    end
+  end
+
   describe "#create" do
     it "creates a record of the appointment request" do
       availability = FactoryGirl.create(:availability)


### PR DESCRIPTION
Interested if y'all are interested in this feature. As a frequent mentor, I sometimes end up with multiple mentees requesting my time. I'm not against that per se -- better that than wasting the availability -- but given the mentees don't see that there's an existing request, I feel like this is a recipe for disappointment.

Thoughts?